### PR TITLE
Do some minor cleanup to OCR text

### DIFF
--- a/generate_static_site.py
+++ b/generate_static_site.py
@@ -8,6 +8,8 @@ import json
 import record
 import re
 
+from ocr import cleaner
+
 # strip leading 'var popular_photos = ' and trailing ';'
 popular_photos = json.loads(open('viewer/static/js/popular-photos.js', 'rb').read()[20:-2])
 pop_ids = {x['id'] for x in popular_photos}
@@ -24,6 +26,8 @@ for photo_id, width, height in csv.reader(open('nyc-image-sizes.txt')):
 
 # ocr.json maps "12345b" -> text. We need photo id -> text.
 back_id_to_text = json.load(open('ocr/ocr.json', 'rb'))
+for k, txt in back_id_to_text.iteritems():
+    back_id_to_text[k] = cleaner.clean(txt)
 id_to_text = {}
 for photo_id in id_to_record.iterkeys():
     back_id = 'book' + re.sub(r'f?(?:-[a-z])?$', 'b', photo_id)

--- a/ocr/cleaner.py
+++ b/ocr/cleaner.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+'''Clean up a few common warts in the OCR data from Ocropus.
+
+These include:
+    - \& --> &
+    - '' --> "
+    - Dropping "NO REPRODUCTIONS" lines
+'''
+
+import json
+import re
+
+import editdistance
+
+
+def swap_chars(txt):
+    return re.sub(r"''", '"', re.sub(r'\\&', '&', txt))
+
+
+# See https://github.com/danvk/oldnyc/issues/39
+WARNINGS = [
+  'NO REPRODUCTIONS',
+  'MAY BE REPRODUCED',
+  'CREDIT LINE IMPERATIVE',
+  'CREDIT LINE IMPERATIVE ON ALL REPRODUCTIONS'
+]
+
+
+def is_warning(line):
+    line = re.sub(r'[,.]$', '', line)
+    for base in WARNINGS:
+        d = editdistance.eval(base, line)
+        if 2 * d < len(base):
+            return True
+    return False
+
+
+def remove_warnings(txt):
+    return '\n'.join(line for line in txt.split('\n') if not is_warning(line))
+
+
+def clean(txt):
+    return remove_warnings(swap_chars(txt))
+
+
+if __name__ == '__main__':
+    ocr = json.load(open('ocr/ocr.json'))
+    for k, txt in ocr.iteritems():
+        clean(txt)
+        #print '%s: %s' % (k, clean(txt))


### PR DESCRIPTION
Fixes #39 

This:
- Changes `\&` → `&`
- Changes `''` → `"` (two single quotes to a double quote)
- Drops `NO REPRODUCTIONS` lines

I dropped all OCR lines within a small edit distance of one of the known attribution lines. These lines tend to have many character recognition issues, so some leeway is important.

The corresponding data update is https://github.com/oldnyc/oldnyc.github.io/commit/65640f3bc3a31e269f4a37ca4c59e1dd9f71c5c5