### PR TITLE
Restyle social+about links

### DIFF
--- a/viewer/static/styles/viewer.css
+++ b/viewer/static/styles/viewer.css
@@ -29,7 +29,7 @@ h2 a {
   right: 0px;
   height: 55px;
   background: transparent;
-  min-width:800px;
+  min-width: 640px;
 }
 
 #map {
@@ -40,28 +40,35 @@ h2 a {
   bottom: 0px;
 }
 
+.boxed {
+  box-shadow: 0px 0px 5px 0px rgba(50, 50, 50, 0.75);
+}
+
 #about {
-  position: absolute;
-  right: 10px;
   font-size: 1.1em;
-  color: #fff;
-  top: 10px;
-  background: rgb(190,0,0);
+  width: 38px;
+  margin: -15px;
+  padding: 15px;
+  padding-top: 18px;
 }
 #about:hover{
   background: #f6f6f6;
 }
 #about a, #about a:visited {
   color: #111;
-  padding: 18px 15px 17px;
   display: block;
+}
+#facebook {
+  width: 121px;
+}
+#twitter {
+  width: 100px;
 }
 .logo {
   position: absolute;
   left: 10px;
   top: 10px;
   background-color: #fff;
-  box-shadow: 0px 0px 5px 0px rgba(50, 50, 50, 0.75);
 }
 .logo .wrapper {
   font-size: 1.2em;
@@ -82,15 +89,17 @@ h2 a {
   line-height: 1em;
 }
 
-.header .social {
+.header .social-about {
   position: absolute;
   top: 10px;
-  right: 78px;
-  padding: 14px 14px;
-  background: rgb(190,0,0);
+  right: 10px;
+  /* width: 300px; */
+  padding: 15px;
+  padding-bottom: 12px;
+  background: #E0C3C3;
 }
 
-.header .social > div {
+.header .social-about > div {
   float: left;
 }
 
@@ -234,7 +243,6 @@ div.exit:hover {
   right: 10px;
   background: #eee;
   padding: 0 10px;
-  box-shadow: 0px 0px 5px 0px rgba(50, 50, 50, 0.75);
 }
 
 #popular {

--- a/viewer/static/viewer.html
+++ b/viewer/static/viewer.html
@@ -31,25 +31,25 @@
   <div id="map">Loading&hellip;</div>
 
   <div class="header streetview-hide">
-    <div class="social">
+    <div class="social-about boxed">
       <div id="facebook">
         <div class="fb-like" data-href="http://www.oldnyc.org" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true"></div>
       </div>
       <div id="twitter">
         <a href="http://twitter.com/share" class="twitter-share-button" data-count="horizontal" data-via="Old_NYC @NYPL">Tweet</a>
       </div>
+
+      <div id="about"><a href="/about">About</a></div>
     </div>
 
-    <div id="about"><a href="/about">About</a></div>
-
-    <div class="logo">
+    <div class="logo boxed">
       <div class="wrapper">
         <a href="/">OldNYC</a>
         <div class="slogan">Mapping historical<br>photos from the NYPL</div>
       </div>
     </div>
 
-    <div class="popular-link" style="display: none">
+    <div class="popular-link boxed" style="display: none">
       <h2><a href="#">Popular Photos</a></h2>
     </div>
   </div>
@@ -57,7 +57,7 @@
   <div id="feedback"><a href="https://docs.google.com/forms/d/1aFi1w4PY1Q-LofWDcPz0CKOyAno6eHNFaVS4x1glwlQ/viewform" target="_blank">Send feedback</a></div>
 
   <!-- Popular Photos -->
-  <div id="popular">
+  <div id="popular" class="boxed">
     <h2>Popular Photos</h2>
     <div class="close">✕</div>
     <div class="popular-photo" id="popular-photo-template" style="display:none">


### PR DESCRIPTION
Here's what the top right bar looks like after this change:
![screen shot 2015-04-29 at 3 20 20 pm](https://cloud.githubusercontent.com/assets/98301/7399367/5ef07510-ee83-11e4-9a71-69056b2fe1fc.png)

I'm still not sure what I think about the color. The social links still move around and resize as the page loads. But I think this is progress.