### PR TITLE
Merge consecutive lines in a paragraph

### DIFF
--- a/ocr/cleaner.py
+++ b/ocr/cleaner.py
@@ -5,6 +5,7 @@ These include:
     - \& --> &
     - '' --> "
     - Dropping "NO REPRODUCTIONS" lines
+    - Merging lines into paragraphs
 '''
 
 import json
@@ -14,6 +15,7 @@ import editdistance
 
 
 def swap_chars(txt):
+    '''Remove a few common Ocropusisms, like \& and '' '''
     return re.sub(r"''", '"', re.sub(r'\\&', '&', txt))
 
 
@@ -36,15 +38,55 @@ def is_warning(line):
 
 
 def remove_warnings(txt):
+    '''Remove lines like "NO REPRODUCTIONS".'''
     return '\n'.join(line for line in txt.split('\n') if not is_warning(line))
 
 
+def merge_lines(txt):
+    '''Merge sequential lines in a paragraph into a single line.
+
+    This can't be done reliably from just the OCR'd text -- it would be better
+    to do this using the bounding boxes of the original images -- but the
+    monospaced font allows a reasonable approximation. Merging these lines is
+    essential for letting the browser reflow the text, especially on narrower
+    screens.
+    '''
+    lines = txt.split('\n')
+    width = max(len(line) for line in lines)
+    join_width = width - 15
+    if join_width < 25:
+        return txt  # be conservative
+
+    txt = ''
+    for i, line in enumerate(lines):
+        is_hyphen = False
+        if line.endswith('-'):
+            # A hyphen at end of line is an automatic join.
+            txt += line[:-1]
+            continue
+
+        txt += line
+        if len(line) < join_width:
+            txt += '\n'
+        elif i < len(lines) - 1 and len(lines[i + 1]) < join_width:
+            txt += '\n'
+        else:
+            txt += ' '
+    if txt.endswith('\n\n'):
+        txt = txt[:-1]
+    return txt
+
+
 def clean(txt):
-    return remove_warnings(swap_chars(txt))
+    return merge_lines(remove_warnings(swap_chars(txt)))
 
 
 if __name__ == '__main__':
     ocr = json.load(open('ocr/ocr.json'))
     for k, txt in ocr.iteritems():
+        print k
         clean(txt)
-        #print '%s: %s' % (k, clean(txt))
+        # print '%s:\n%s\n\n-----\n' % (k, clean(txt))
+        #txt = clean(txt)
+        # txt = '\n'.join('%2d %s' % (len(line), line) for line in txt.split('\n'))
+        # print '%s:\n%s\n\n------\n' % (k, txt)

--- a/ocr/cleaner_test.py
+++ b/ocr/cleaner_test.py
@@ -1,0 +1,137 @@
+from nose.tools import *
+
+from ocr import cleaner
+
+samples = [
+# 0
+'''120-130 Baxter Street, west side, at, adjoining, and south of
+the S.W. corner of Hester Street. The view also shows 200-202 Hester
+Street, at and adjoining the S.W. corner of Baxter Street.
+About 1925.
+MAY BE REPRODUCED.
+''',
+
+# 1
+'''The 440 Club was a popular downstairs watering hole for
+local office inhabitants. So named - 4 East 40th. After
+losing 1ease it became a restaurant which failed within a
+short time. Bldg will be demolished to sske way for new
+(proposed) hoae of Ihe Republic National Bank.
+Earl Christian, photographer (NnPL)
+Aug.1979
+''',
+
+# 2
+'''1. Panorama from hill above Swan St., Stapleton, S.I.
+Sept. 7, 1939
+P.L. Sperr, photographer
+ce. Sane as above
+3. Same as above
+''',
+
+# 3
+'''(1)
+Eleventh Avenue at northeast cornsr of 57th Street,
+and showing buildings on north west side of Avenue.
+May 20, 1927.
+(2)
+Eleventh Avenue northeast corner 57th Street, Gas
+Sfation in plain site.
+P.L.Speer.
+NO REPRODU IONS.  September 19, 1933.
+''',
+
+# 4
+'''308 E. 37th Street, south side, east of Second Avenue.
+The easterly half of St. Gabriel's Roman Catholic Church as
+viewed northwaro from the alter rail. TCo the lett appears the
+organ loft and the large stained window that is over the entrance.
+.January 11, 1939
+Somach Yhoto Service
+New York City Tunnel Authority
+CPDlr LLND IEERA1IvE
+''',
+
+# 5
+'''New Dock Street, west side, north of Water Street, show-
+ing W. P. S. workmen erecting a new storehouse for the New York
+City Department of Purchase under the Brooklyn Bridge.
+June 17, 1936
+Works Progress Administration
+Project 65-97-68
+CREDIT LINE IMPERATIVE
+''',
+
+# 6
+'''Coney Island: The beach and boardwalk on a hot August after-
+noon, looking east.
+1939
+Alexaneer Alland
+Ap7-:  Wg ~E 33~4
+'''
+]
+
+
+def test_remove_warning():
+    assert 'MAY BE REPRODUCED' in samples[0]
+    assert 'MAY BE REPRODUCED' not in cleaner.remove_warnings(samples[0])
+
+    assert 'CPDlr LLND IEERA1IvE' in samples[4]
+    assert 'CPDlr LLND IEERA1IvE' not in cleaner.remove_warnings(samples[4])
+
+
+def test_merge_lines():
+    txt = cleaner.remove_warnings(samples[0])
+    eq_('''120-130 Baxter Street, west side, at, adjoining, and south of the S.W. corner of Hester Street. The view also shows 200-202 Hester Street, at and adjoining the S.W. corner of Baxter Street.
+About 1925.
+''',
+    cleaner.merge_lines(txt))
+
+    txt = cleaner.remove_warnings(samples[1])
+    eq_('''The 440 Club was a popular downstairs watering hole for local office inhabitants. So named - 4 East 40th. After losing 1ease it became a restaurant which failed within a short time. Bldg will be demolished to sske way for new (proposed) hoae of Ihe Republic National Bank.
+Earl Christian, photographer (NnPL)
+Aug.1979
+''',
+    cleaner.merge_lines(txt))
+
+    txt = cleaner.remove_warnings(samples[2])
+    eq_(txt, cleaner.merge_lines(txt))
+
+    # XXX: it would be better if the "Sfation" line were merged up.
+    txt = cleaner.remove_warnings(samples[3])
+    eq_('''(1)
+Eleventh Avenue at northeast cornsr of 57th Street, and showing buildings on north west side of Avenue.
+May 20, 1927.
+(2)
+Eleventh Avenue northeast corner 57th Street, Gas
+Sfation in plain site.
+P.L.Speer.
+NO REPRODU IONS.  September 19, 1933.
+''',
+    cleaner.merge_lines(txt))
+
+    txt = cleaner.remove_warnings(samples[4])
+    eq_('''308 E. 37th Street, south side, east of Second Avenue. The easterly half of St. Gabriel's Roman Catholic Church as viewed northwaro from the alter rail. TCo the lett appears the organ loft and the large stained window that is over the entrance.
+.January 11, 1939
+Somach Yhoto Service
+New York City Tunnel Authority
+''',
+    cleaner.merge_lines(txt))
+
+    # This one has a hyphenated phrase which gets joined
+    txt = cleaner.remove_warnings(samples[5])
+    eq_('''New Dock Street, west side, north of Water Street, showing W. P. S. workmen erecting a new storehouse for the New York City Department of Purchase under the Brooklyn Bridge.
+June 17, 1936
+Works Progress Administration
+Project 65-97-68
+''',
+    cleaner.merge_lines(txt))
+
+    # This one has a hyphen followed by a short line.
+    txt = cleaner.remove_warnings(samples[6])
+    eq_('''Coney Island: The beach and boardwalk on a hot August afternoon, looking east.
+1939
+Alexaneer Alland
+Ap7-:  Wg ~E 33~4
+''',
+    cleaner.merge_lines(txt))

--- a/ocr/noise/README.md
+++ b/ocr/noise/README.md
@@ -33,6 +33,9 @@ E5 2  w. wJ
 2N48wwww--
 7: N6e -e
 
+3 7:8:\ne2E\nH\nW b)1\na. 2E\nSpge  Hf ewhi\ns2  ed tb\norN:\nE w4 N\n' -\nL.. 6h  Eo  w 1\nsg  BN..\nM 0:\nr8 o 44\ne~w\nEPa\nNzw. d\nS E 2\nE o\nE P I\ntw W N\n- pE\nMw hi ct\nt cw 0\nrrR\ng's\ng: Mf nn.\nEY k-\nBs\nE.E\n8ac3\nS y aE\ni oo w\ng ~\nNs\nS\nEa:\n
+Ee3R:EEfSPE1T3S1  ..NS~SSpEz2M228260--\n90SP17\nCac V0gE\nCabe.e. 2-( eeATY 2A /~ J~\nNeg. ~ SO21
+
 
 Upside-down:
 


### PR DESCRIPTION
This uses some heuristics based on the font being fixed width. It would be better to do this using the bounding boxes from `ocropus-gpageseg`. (See #59)

This generally works pretty well. The one consistent problem is that, if the last line in a paragraph is short, it will remain on its own line.

Corresponding data update: https://github.com/oldnyc/oldnyc.github.io/commit/045c946c01b3f9645d1136953b4fea912898277a
Fixes #47 