### PR TITLE
Production Cloudfront Links

### DIFF
--- a/viewer/static/about.html
+++ b/viewer/static/about.html
@@ -10,7 +10,7 @@
     margin-left: 0;
     width: 387px;
     height: 292px;
-    background: url(http://images.oldnyc.org/600px/711343f-a.jpg);
+    background: url(http://oldnyc-assets.nypl.org/600px/711343f-a.jpg);
     background-repeat: no-repeat;
     background-position: -110px -55px;
   }
@@ -27,14 +27,14 @@
 
 <div id="content-area">
   <div id="title"><a href="/about">About OldNYC</a></div>
-  <a href="/#1558433"><img style="float: right; padding: 15px; padding-right: 0; padding-top: 10px;" border=0 src="http://images.oldnyc.org/600px/1558433.jpg" width=600 height=473 /></a>
+  <a href="/#1558433"><img style="float: right; padding: 15px; padding-right: 0; padding-top: 10px;" border=0 src="http://oldnyc-assets.nypl.org/600px/1558433.jpg" width=600 height=473 /></a>
 
   <p>This site provides an alternative way of browsing the <a
   href="http://www.nypl.org/">NYPL</a>'s incredible <a
   href="http://digitalgallery.nypl.org/nypldigital/explore/dgexplore.cfm?col_id=219">Photographic
   Views of New York City, 1870s-1970s</a> collection. Its goal is to help you
 discover the history behind the places you see every day.</p>
-  
+
   <p>And, if you're lucky, maybe you'll even discover something about New
   York's rich past that you never knew before!</p>
 
@@ -73,7 +73,7 @@ discover the history behind the places you see every day.</p>
   href="http://www.danvk.org/wp/2013-02-09/finding-pictures-in-pictures/">here</a>
 and <a
 href="http://www.danvk.org/wp/2013-04-20/generating-training-data/">here</a>.</p>
-  
+
 
   <a href="/#711343f-a"><div class="google-building"></div></a>
   <h3>What's the story of this project?</h3>

--- a/viewer/static/js/bundle.js
+++ b/viewer/static/js/bundle.js
@@ -333,11 +333,11 @@ var end_date = 2000;
 var mapPromise = $.Deferred();
 
 function thumbnailImageUrl(photo_id) {
-  return 'http://images.oldnyc.org/thumb/' + photo_id + '.jpg';
+  return 'http://oldnyc-assets.nypl.org/thumb/' + photo_id + '.jpg';
 }
 
 function expandedImageUrl(photo_id) {
-  return 'http://images.oldnyc.org/600px/' + photo_id + '.jpg';
+  return 'http://oldnyc-assets.nypl.org/600px/' + photo_id + '.jpg';
 }
 
 // lat_lon is a "lat,lon" string.

--- a/viewer/static/js/viewer.js
+++ b/viewer/static/js/viewer.js
@@ -10,11 +10,11 @@ var end_date = 2000;
 var mapPromise = $.Deferred();
 
 function thumbnailImageUrl(photo_id) {
-  return 'http://images.oldnyc.org/thumb/' + photo_id + '.jpg';
+  return 'http://oldnyc-assets.nypl.org/thumb/' + photo_id + '.jpg';
 }
 
 function expandedImageUrl(photo_id) {
-  return 'http://images.oldnyc.org/600px/' + photo_id + '.jpg';
+  return 'http://oldnyc-assets.nypl.org/600px/' + photo_id + '.jpg';
 }
 
 // lat_lon is a "lat,lon" string.

--- a/viewer/static/viewer.html
+++ b/viewer/static/viewer.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="website" />
   <meta property="og:url" content="http://www.oldnyc.org/" />
   <meta property="og:description" content="OldNYC shows 40,000 historical images from the New York Public Library's Milstein Collection on a map. Find photos of your apartment, work, or favorite park!" />
-  <meta property="og:image" content="http://images.oldnyc.org/600px/723905f-a.jpg" />
+  <meta property="og:image" content="http://oldnyc-assets.nypl.org/600px/723905f-a.jpg" />
 
   <meta name="Description" content="OldNYC shows 40,000 historical images from the New York Public Library's Milstein Collection on a map. Find photos of your apartment, work, or favorite park!" />
 </head>


### PR DESCRIPTION
(Cleaned up version of #62)

Uses NYPL S3->Cloudfront->DNS

Closes #51.