### PR TITLE
Feedback over CORS

### DIFF
--- a/viewer/app.yaml
+++ b/viewer/app.yaml
@@ -15,6 +15,8 @@ handlers:
 - url: /about
   static_files: static/about.html
   upload: static/about.html
+- url: /rec_feedback
+  script: app.app
 
 - url: /upload
   script: app.app

--- a/viewer/app.yaml
+++ b/viewer/app.yaml
@@ -1,6 +1,6 @@
 application: old-nyc
 
-version: 2015-05-11
+version: 2015-05-13
 runtime: python27
 threadsafe: true
 

--- a/viewer/feedback.py
+++ b/viewer/feedback.py
@@ -21,6 +21,13 @@ COOKIE_NAME = 'feedback_cookie'
 
 
 class RecordFeedback(webapp2.RequestHandler):
+    def options(self):
+        r = self.response
+        r.headers.add_header('Access-Control-Allow-Origin', '*')
+        r.headers.add_header('Access-Control-Allow-Methods',
+                             'GET, POST, OPTIONS')
+        r.out.write('OK')
+
     def post(self):
         self.get()
 

--- a/viewer/static/js/bundle.js
+++ b/viewer/static/js/bundle.js
@@ -335,6 +335,8 @@ var map;
 var start_date = 1850;
 var end_date = 2000;
 
+var FEEDBACK_URL = 'http://www.oldnyc.org/rec_feedback';
+
 var mapPromise = $.Deferred();
 
 function thumbnailImageUrl(photo_id) {
@@ -661,7 +663,7 @@ function hideAbout() {
 
 function sendFeedback(photo_id, feedback_obj) {
   ga('send', 'event', 'link', 'feedback', { 'page': '/#' + photo_id });
-  return $.ajax('/rec_feedback', {
+  return $.ajax(FEEDBACK_URL, {
     data: { 'id': photo_id, 'feedback': JSON.stringify(feedback_obj) },
     method: 'post'
   }).fail(function() {

--- a/viewer/static/js/viewer.js
+++ b/viewer/static/js/viewer.js
@@ -7,6 +7,8 @@ var map;
 var start_date = 1850;
 var end_date = 2000;
 
+var FEEDBACK_URL = 'http://www.oldnyc.org/rec_feedback';
+
 var mapPromise = $.Deferred();
 
 function thumbnailImageUrl(photo_id) {
@@ -333,7 +335,7 @@ function hideAbout() {
 
 function sendFeedback(photo_id, feedback_obj) {
   ga('send', 'event', 'link', 'feedback', { 'page': '/#' + photo_id });
-  return $.ajax('/rec_feedback', {
+  return $.ajax(FEEDBACK_URL, {
     data: { 'id': photo_id, 'feedback': JSON.stringify(feedback_obj) },
     method: 'post'
   }).fail(function() {


### PR DESCRIPTION
This should facilitate migration to GitHub pages hosting. The AppEngine app can be kept around as a feedback collector.

Fixes #68 