### PR TITLE
Mechanism for OCR correction

### DIFF
--- a/viewer/app.yaml
+++ b/viewer/app.yaml
@@ -15,6 +15,9 @@ handlers:
 - url: /about
   static_files: static/about.html
   upload: static/about.html
+- url: /ocr.html
+  static_files: static/ocr.html
+  upload: static/ocr.html
 - url: /rec_feedback
   script: app.app
 

--- a/viewer/static/ocr.html
+++ b/viewer/static/ocr.html
@@ -1,0 +1,146 @@
+<html>
+<head>
+<title>OldNYC OCR Correction</title>
+<style>
+#image {
+  position: absolute;
+  width: 500px;
+}
+#image p {
+  font-style: italic;
+}
+
+#ocr {
+  background: white;
+  position: absolute;
+  left: 510px;
+  right: 10px;
+  min-width: 500px;
+  max-width: 800px;
+}
+h3 {
+  margin-top: 0;
+}
+.instructions {
+  max-width: 500px;
+}
+
+textarea {
+  font-family: monospace;
+  font-size: 20px;
+  width: 100%;
+}
+button {
+  font-size: 20px;
+}
+#thanks {
+  display: none;
+  font-weight: bold;
+  color: green;
+  text-align: center;
+}
+</style>
+</head>
+
+<body>
+<p><a id="back-link" href="/">← Back to OldNYC</a></p>
+<p id="thanks">Thanks for your contribution! Your changes should appear on OldNYC within a few days.</p>
+<div id="image">
+  <img>
+  <p>You might find a <a target="_blank" id="hi-res">higher-resolution image</a> on the NYPL site.</p>
+</div>
+<div id="ocr">
+  <h3>OldNYC OCR Correction</h3>
+  <p class="instructions">
+  Please adjust the text on the right to match what you see on the left. When
+  you're done, hit the "Submit" button. There's no need to include reuse lines
+  like "MAY BE REPRODUCED" or "NO REPRODUCTIONS". If the text is already
+  perfect, just hit "Submit". If there's no text on the card, hit "No Text".
+  </p>
+  <textarea id="text" rows="25"></textarea>
+  <p>
+    <button id="notext">No Text</button>
+    <button id="submit" style="float:right">Submit</button>
+  </p>
+</div>
+
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+<!-- Proxy XHRs to oldnyc.github.io using xdomain -->
+<script src="//cdn.rawgit.com/jpillora/xdomain/0.6.17/dist/xdomain.min.js" slave="http://oldnyc.github.io/proxy.html"></script>
+<script src="js/photo-info.js"></script>
+<script src="js/url-state.js"></script>
+
+<script>
+var FEEDBACK_URL = 'http://www.oldnyc.org/rec_feedback';
+// var FEEDBACK_URL = '/rec_feedback';
+
+if (window.location.search.indexOf('thanks') >= 0) {
+  $('#thanks').show();
+}
+
+var id = window.location.hash.slice(1);
+$('[name="photo_id"]').val(id);
+$('#back-link').attr('href', '/#' + id);
+$('#hi-res').attr('href', libraryUrlForPhotoId(id));
+var this_lat_lon, other_photo_ids;
+findLatLonForPhoto(id, function(lat_lon) {
+  this_lat_lon = lat_lon;
+  loadInfoForLatLon(lat_lon).then(function(photo_ids) {
+    var info = infoForPhotoId(id);
+    other_photo_ids = photo_ids;
+    $('#image img').attr('src', backOfCardUrlForPhotoId(id));
+    var text = info['text'];
+    if (text) {
+      $('#text').text(info['text']);
+    }
+    $('#submit').click(function() {
+      submit({text: $('#text').val()});
+    });
+    $('#notext').click(function() {
+      submit({notext: true});
+    });
+  });
+});
+
+function submit(feedback_obj) {
+  sendFeedback(id, feedback_obj)
+    .done(function() {
+      // Go to another image at the same location.
+      var next_id = next_image(id);
+      var url = location.protocol + '//' + location.host + location.pathname +
+                '?thanks#' + next_id;
+      window.location = url;
+      window.location.reload();
+    });
+}
+
+function sendFeedback(photo_id, feedback_obj) {
+  return $.ajax(FEEDBACK_URL, {
+    data: { 'id': photo_id, 'feedback': JSON.stringify(feedback_obj) },
+    method: 'post'
+  }).fail(function() {
+    alert('Unable to send correction for', photo_id)
+  });
+}
+
+// Find the next image from a different card.
+function next_image(id) {
+  var idx = other_photo_ids.indexOf(id);
+  for (var i = 0; i < other_photo_ids.length; i++) {
+    var other_id = other_photo_ids[(i + idx) % other_photo_ids.length];
+
+    if (!other_id.match(/[0-9]f/)) {
+      // no back of card for this photo
+      continue;
+    }
+
+    if (backOfCardUrlForPhotoId(other_id) != backOfCardUrlForPhotoId(id)) {
+      return other_id;
+    }
+  }
+  return id;
+}
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Fixes #40 

The page is pretty spartan, but it gets the job done. When you submit a correction, it's logged in the usual OldNYC feedback queue. I'll build out something to use all this information after the launch. After submitting a correction, you're presented with another image. Hopefully users will go on a text correction rampage!

![ocr correction](https://cloud.githubusercontent.com/assets/98301/7683562/e8d9acd2-fd4d-11e4-9ce9-c0c8975e976e.png)
