### PR TITLE
Output information to debug geocodes to site

### DIFF
--- a/oldnyc/geocode/generate_js.py
+++ b/oldnyc/geocode/generate_js.py
@@ -78,6 +78,10 @@ def output_geojson(
                 }
             ),
         }
+        if geocode.failures:
+            props["geocode_failures"] = [
+                {"technique": coder, **locatable_to_dict(loc)} for coder, loc in geocode.failures
+            ]
 
         feature: GeoJsonFeature = {
             "id": r.id,

--- a/oldnyc/site/generate_static_site.py
+++ b/oldnyc/site/generate_static_site.py
@@ -54,7 +54,7 @@ for r in rs:
     item_id_to_photo_ids[item_id].append(r.id)
 
 geocoded_features: list[GeoJsonFeature] = [
-    f for f in json.load(open("data/images.geojson"))["features"] if f["geometry"]
+    f for f in json.load(open("data/images.geojson"))["features"]
 ]
 item_id_to_geocoded_feature = {f["id"]: f for f in geocoded_features}
 lat_lon_to_item_ids = dict[str, list[str]]()
@@ -152,6 +152,9 @@ def make_response(photo_ids: Iterable[str]):
             h = 600
         ocr_text, text_source = id_to_text.get(photo_id) or (None, None)
 
+        item_id = r.id.split("-")[0]
+        geocoded_feature = item_id_to_geocoded_feature[item_id]
+
         title = r.title
         original_title = None
         if is_pure_location(title):
@@ -196,7 +199,12 @@ def make_response(photo_ids: Iterable[str]):
             "thumb_url": image_url(photo_id, is_thumb=True),
             "nypl_url": f"https://digitalcollections.nypl.org/items/{r.uuid}",
             # TODO: switch to r.url after reviewing other diffs
+            "nypl_fields": geocoded_feature["properties"]["nypl_fields"],
+            "geocode": geocoded_feature["properties"]["geocode"],
         }
+        geocode_failures = geocoded_feature["properties"].get("geocode_failures")
+        if geocode_failures:
+            resp["geocode_failures"] = geocode_failures
         if original_title:
             resp["original_title"] = original_title
         if rotation:

--- a/oldnyc/site/site_data_type.py
+++ b/oldnyc/site/site_data_type.py
@@ -37,6 +37,9 @@ class SiteResponse(SiteItem):
     """Type of the entries in by-location/*.json"""
 
     id: str
+    nypl_fields: Any
+    geocode: Any
+    geocode_failures: NotRequired[list[Any]]
 
 
 class Timestamps(TypedDict):


### PR DESCRIPTION
Follow-up to #193, see #189 

These fields are invisible for now but I may incorporate them into the site later. You can see them in the JS console by alt/option-clicking the "Copy Link" button.

Data update: https://github.com/oldnyc/oldnyc.github.io/commit/5852b4594971a56656643790bd6ba8b3d3590635

This makes files ~60% larger. This is fine for the `by-location` files, which are all small. It increases `data.json` from 44M -> 75M. GitHub generates a warning on push for files larger than 50MB and blocks files above 100MB, so something to keep an eye on.